### PR TITLE
Svg 다이얼 회전

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -714,18 +714,8 @@ export default function SVGBoilingAnimation() {
     }
   }, [svgContent, applyFilters])
 
-  // 컴포넌트 마운트 시 초기 설정
+  // 컴포넌트 마운트 시 초기 설정 (마운트 시 1회만 실행)
   useEffect(() => {
-    // 초기 각도를 값에 맞춰 0~350도로 설정
-    const initialRotation = valueToAngle(TREMOR_MIN, TREMOR_MIN, TREMOR_MAX)
-    const initialRotation2 = valueToAngle(INTENSITY_MIN, INTENSITY_MIN, INTENSITY_MAX)
-    tremorValueRef.current = TREMOR_MIN
-    intensityValueRef.current = INTENSITY_MIN
-    currentRotationRef.current = initialRotation
-    currentRotation2Ref.current = initialRotation2
-    setCurrentRotation(initialRotation)
-    setCurrentRotation2(initialRotation2)
-
     // 초기 필터 적용
     const timer = setTimeout(() => {
       applyFilters()
@@ -736,9 +726,13 @@ export default function SVGBoilingAnimation() {
 
     return () => {
       clearTimeout(timer)
-      stopAnimation()
+      if (animationIntervalRef.current) {
+        clearInterval(animationIntervalRef.current)
+        animationIntervalRef.current = null
+      }
     }
-  }, [applyFilters, startAnimation, stopAnimation, valueToAngle])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     if (isAnimating) {


### PR DESCRIPTION
Fixes the SVG dial not rotating by preventing its initialization `useEffect` from re-running and resetting its value on every change.

The `useEffect` responsible for initial setup was configured with dependencies that indirectly relied on `tremorValue` and `intensityValue`. When these values changed (e.g., by user interaction with the dial), the `useEffect` would re-execute, resetting `tremorValueRef.current` to its minimum, which caused the dial to snap back to its initial position instead of rotating.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-772ce66c-bf28-4b2d-b472-19d9ab446477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-772ce66c-bf28-4b2d-b472-19d9ab446477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

